### PR TITLE
Add stricter permissions for ModelChooser API views

### DIFF
--- a/wagtailmodelchoosers/permissions.py
+++ b/wagtailmodelchoosers/permissions.py
@@ -1,0 +1,13 @@
+from django.contrib.auth.models import Permission
+
+from rest_framework.permissions import BasePermission
+
+
+class IsWagtailAdmin(BasePermission):
+
+    @property
+    def _permission(self):
+        return Permission.objects.get(name=u'Can access Wagtail admin')
+
+    def has_permission(self, request, view):
+        return request.user.is_authenticated() and request.user.has_perm(self._permission)

--- a/wagtailmodelchoosers/permissions.py
+++ b/wagtailmodelchoosers/permissions.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import Permission
+from django.conf import settings
 
 from rest_framework.permissions import BasePermission
 
@@ -11,3 +12,17 @@ class IsWagtailAdmin(BasePermission):
 
     def has_permission(self, request, view):
         return request.user.is_authenticated() and request.user.has_perm(self._permission)
+
+
+class IsRegisteredModelChooserModel(BasePermission):
+
+    def has_permission(self, request, view):
+        params = request.parser_context.get('kwargs')
+        app_name = params.get('app_name')
+        model_name = params.get('model_name')
+
+        model_path = u'{}.{}'.format(app_name, model_name)
+        return model_path in self.configured_model_chooser_models()
+
+    def configured_model_chooser_models(self):
+        return [chooser['content_type'] for chooser in settings.MODEL_CHOOSERS_OPTIONS.values()]

--- a/wagtailmodelchoosers/views.py
+++ b/wagtailmodelchoosers/views.py
@@ -13,12 +13,13 @@ from rest_framework.viewsets import GenericViewSet, ViewSet
 from wagtailmodelchoosers.paginators import GenericModelPaginator
 from wagtailmodelchoosers.utils import get_chooser_options, get_query_keys_map, get_response_keys_map
 from wagtailmodelchoosers.permissions import IsWagtailAdmin
+from wagtailmodelchoosers.permissions import IsRegisteredModelChooserModel
 
 
 class ModelView(ListModelMixin, GenericViewSet):
     pagination_class = GenericModelPaginator
     authentication_classes = (SessionAuthentication, BasicAuthentication)
-    permission_classes = (IsAuthenticated, IsWagtailAdmin)
+    permission_classes = (IsAuthenticated, IsWagtailAdmin, IsRegisteredModelChooserModel)
     filter_backends = (filters.DjangoFilterBackend, filters.SearchFilter,)
 
     def get_params(self):

--- a/wagtailmodelchoosers/views.py
+++ b/wagtailmodelchoosers/views.py
@@ -12,12 +12,13 @@ from rest_framework.viewsets import GenericViewSet, ViewSet
 
 from wagtailmodelchoosers.paginators import GenericModelPaginator
 from wagtailmodelchoosers.utils import get_chooser_options, get_query_keys_map, get_response_keys_map
+from wagtailmodelchoosers.permissions import IsWagtailAdmin
 
 
 class ModelView(ListModelMixin, GenericViewSet):
     pagination_class = GenericModelPaginator
     authentication_classes = (SessionAuthentication, BasicAuthentication)
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, IsWagtailAdmin)
     filter_backends = (filters.DjangoFilterBackend, filters.SearchFilter,)
 
     def get_params(self):
@@ -97,7 +98,7 @@ class ModelView(ListModelMixin, GenericViewSet):
 
 class RemoteResourceView(ViewSet):
     authentication_classes = (SessionAuthentication, BasicAuthentication)
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, IsWagtailAdmin)
     filter_backends = (filters.DjangoFilterBackend, filters.SearchFilter,)
     http_method_names = ('get', 'head', 'options')
 


### PR DESCRIPTION
The permission classes on the APIs for fetching results for ModelChooser lookups only required the user to be logged in, meaning any logged-in user can read all data from tables with this lookup exposed.

The API also exposed a view to fetch all data from any model specified in the request. This also adds a permission class requiring that the model is configured with a ModelChooser