### PR TITLE
Force unicode to str to fix TypeError

### DIFF
--- a/wagtailmodelchoosers/views.py
+++ b/wagtailmodelchoosers/views.py
@@ -90,7 +90,7 @@ class ModelView(ListModelMixin, GenericViewSet):
                 'content_type': serializers.StringRelatedField()
             })
 
-        model_serializer = type(class_name, (serializers.ModelSerializer,), serializer_args)
+        model_serializer = type(str(class_name), (serializers.ModelSerializer,), serializer_args)
 
         return model_serializer
 


### PR DESCRIPTION
type() can only accept str and not unicode. Force to str to prevent
TypeError in cases where arg is unicode