### PR TITLE
Add support for custom search fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,11 @@ You can optionally specify the rest-framework serializer that is used to seriali
             from myapp.serialziers import MyModelSerializer
             return MyModelSerializer
 
+Search fields for the model can be defined on the class via the property `SEARCH_FIELDS`
+.. code:: python
+    class MyModel(models.Model):
+        SEARCH_FIELDS = ('name__istartswith',)
+
 In addition, you can customise the mapping of the key of the API, see the configuration key names being used for the `query <https://github.com/springload/wagtailmodelchoosers/blob/c36bb877eef4ac4af6b221f0d7ff7416354754c7/wagtailmodelchoosers/utils.py#L107-L112>`_ and the `response <https://github.com/springload/wagtailmodelchoosers/blob/c36bb877eef4ac4af6b221f0d7ff7416354754c7/wagtailmodelchoosers/utils.py#L115-L123>`_.
 
 

--- a/wagtailmodelchoosers/views.py
+++ b/wagtailmodelchoosers/views.py
@@ -31,12 +31,16 @@ class ModelView(ListModelMixin, GenericViewSet):
             return queryset
 
         queries = []
-        for field in cls._meta.get_fields():
-            if isinstance(field, CharField):
-                kwargs = {}
-                param_name = '%s__icontains' % field.name
-                kwargs[param_name] = search
-                queries.append(Q(**kwargs))
+        if hasattr(cls, 'SEARCH_FIELDS'):
+            queries = [Q(**{search_field: search}) for search_field in cls.SEARCH_FIELDS]
+        else:
+            search_fields = [field.name for field in cls._meta.get_fields() if isinstance(field, CharField)]
+            for field in cls._meta.get_fields():
+                if isinstance(field, CharField):
+                    kwargs = {}
+                    param_name = '%s__icontains' % field.name
+                    kwargs[param_name] = search
+                    queries.append(Q(**kwargs))
 
         if len(queries):
             query = queries.pop()


### PR DESCRIPTION
# Problem
Previous implementation only used `CharField`s on the model to do searches from the chooser. This does not work with more complicated models

# Solution
Default to the original implementation, but if `SEARCH_FIELDS` is defined on the model, use that for the lookup instead.