### PR TITLE
Add paginated suggestions support

### DIFF
--- a/wagtailmodelchoosers/client/components/AutoComplete.js
+++ b/wagtailmodelchoosers/client/components/AutoComplete.js
@@ -12,6 +12,7 @@ const propTypes = {
   onLoadSuggestions: PropTypes.func.isRequired,
   onLoadStart: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
+  onClearSearch: PropTypes.func.isRequired,
   endpoint: PropTypes.string.isRequired,
   filter: PropTypes.string,
 };
@@ -43,7 +44,7 @@ class AutoComplete extends Component {
           suggestions: json.results,
           loading: false,
         }, () => {
-          onLoadSuggestions(json.results);
+          onLoadSuggestions(json);
         });
       });
   }
@@ -62,6 +63,10 @@ class AutoComplete extends Component {
     }, () => {
       onChange(newValue);
     });
+
+    if (newValue.length === 0) {
+      this.props.onClearSearch();
+    }
   }
 
   render() {


### PR DESCRIPTION
# Problem
The implementation of the  AutoComplete meant there were 2 different sets of results that can be displayed, the initialData and the suggestions. Because of this, a flag was used that only allows pagination to function on the initial data and not on suggestions.
# Solution
When using the autosuggest, put the pagination urls into the picker state such that pagination can be applied to search results as well. Clear these pagination overrides if search field is cleared.