### PR TITLE
Add Django Admin create popup link

### DIFF
--- a/wagtailmodelchoosers/client/components/BaseChooser.js
+++ b/wagtailmodelchoosers/client/components/BaseChooser.js
@@ -23,6 +23,7 @@ const propTypes = {
   label: PropTypes.string.isRequired,
   initial_display_value: PropTypes.string.isRequired,
   endpoint: PropTypes.string.isRequired,
+  createEndpoint: PropTypes.string.isRequired,
   value: PropTypes.any,
   required: PropTypes.bool.isRequired,
   display: PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired,
@@ -184,6 +185,7 @@ class BaseChooser extends React.Component {
         {pickerVisible ? (
           <ModelPicker
             url={initialUrl}
+            createEndpoint={this.props.createEndpoint}
             onClose={this.onClose}
             onSelect={this.onSelect}
             {...this.props}

--- a/wagtailmodelchoosers/client/components/ModelPicker.js
+++ b/wagtailmodelchoosers/client/components/ModelPicker.js
@@ -32,6 +32,7 @@ const propTypes = {
   onClose: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
   endpoint: PropTypes.string.isRequired,
+  createEndpoint: PropTypes.string.isRequired,
   value: PropTypes.any,
   required: PropTypes.bool.isRequired,
   display: PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired,
@@ -77,6 +78,7 @@ class ModelPicker extends React.Component {
     this.parseValue = this.parseValue.bind(this);
     this.getRow = this.getRow.bind(this);
     this.getCount = this.getCount.bind(this);
+    this.popupCreateLink = this.popupCreateLink.bind(this);
     this.getCountDisplay = this.getCountDisplay.bind(this);
     this.getPageDisplay = this.getPageDisplay.bind(this);
     this.getPaginationButtons = this.getPaginationButtons.bind(this);
@@ -289,6 +291,25 @@ class ModelPicker extends React.Component {
     );
   }
 
+  popupCreateLink(event) {
+    event.preventDefault();
+    window.open(this.props.createEndpoint, 'createModelInstance', 'width=900,height=600,resizable=yes,scrollbars=yes');
+  }
+
+  getCreateLink() {
+    if (this.props.createEndpoint) {
+      return (
+        <a
+          href={this.props.createEndpoint}
+          onClick={this.popupCreateLink}
+          className="admin-modal__create_link button"
+        >
+          Create New
+        </a>
+      );
+    }
+  }
+
   getCount() {
     return this.state.count;
   }
@@ -418,6 +439,7 @@ class ModelPicker extends React.Component {
               />
             </div>
             <div className="admin-modal__action">
+              {this.getCreateLink()}
               {this.getCountDisplay()}
               {this.getPageDisplay()}
               {this.getPaginationButtons()}

--- a/wagtailmodelchoosers/client/wagtailmodelchoosers.css
+++ b/wagtailmodelchoosers/client/wagtailmodelchoosers.css
@@ -133,6 +133,11 @@
     /*padding-top: .5rem;*/
 }
 
+.admin-modal__create_link {
+    float: left;
+    margin-left: 10px;
+}
+
 .admin-modal__pagination {
     margin-right: 1.5rem;
     display: inline-block;

--- a/wagtailmodelchoosers/client/wagtailmodelchoosers.js
+++ b/wagtailmodelchoosers/client/wagtailmodelchoosers.js
@@ -34,6 +34,14 @@ window.wagtailModelChoosers = {};
 window.wagtailModelChoosers.initModelChooser = initModelChooser;
 window.wagtailModelChoosers.initRemoteModelChooser = initRemoteModelChooser;
 
+// Add hooks to close Django Admin AddInstance popups on-save
+window.dismissRelatedLookupPopup = function (win) {
+  win.close();
+};
+window.dismissAddRelatedObjectPopup = function (win) {
+  win.close();
+};
+
 // Add Sources if WagtailDraftail is available.
 if (window.hasOwnProperty('wagtailDraftail')) {
   window.wagtailDraftail.registerSources({ ModelSource, RemoteModelSource })

--- a/wagtailmodelchoosers/widgets.py
+++ b/wagtailmodelchoosers/widgets.py
@@ -5,6 +5,8 @@ from django.apps import apps
 from django.forms import widgets
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property
+from django.urls.exceptions import NoReverseMatch
+from django.core.urlresolvers import reverse
 
 from wagtail.utils.widgets import WidgetWithScript
 
@@ -80,6 +82,14 @@ class ModelChooserWidget(WidgetWithScript, widgets.Input):
         from django.core.urlresolvers import reverse
         return reverse('wagtailmodelchoosers_api_model', args=[app, class_name])
 
+   def get_create_endpoint(self):
+        app, class_name = self.get_class_name()
+
+        try:
+            return reverse(('admin:%s_%s_add' % (app, class_name)).lower()) + "?_popup=1"
+        except NoReverseMatch:
+            return None
+
     def get_internal_value(self, value):
         if hasattr(value, 'pk'):
             if isinstance(value.pk, uuid.UUID):
@@ -99,6 +109,7 @@ class ModelChooserWidget(WidgetWithScript, widgets.Input):
             'pk_name': self.pk_name,
             'required': self.required,
             'initial_display_value': self.get_display_value(value),
+            'createEndpoint': self.get_create_endpoint(),
             'endpoint': self.get_endpoint(),
         }
 


### PR DESCRIPTION
In the case where an object does not exist in a modelchooser, a writer must open admin in another tab to create the instance, and then select it in the model chooser. This update adds a link to the modelchooser that opens the django admin "add" form for the model in a popup. If the admin link does not resolve (no admin page defined for the model) then the "create" link is not added. Permission management for handling creating the instance is managed via django admin.

<img width="1178" alt="screen shot 2017-09-13 at 5 06 40 pm" src="https://user-images.githubusercontent.com/4490878/30406396-65a9c79c-98a6-11e7-9c74-22455acfdf25.png">
