### PR TITLE
Use chooser settings in view

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ The ModelChooser and RemoteModelChooser share a similar base configuration and o
             ],
             'content_type': 'core.Navigation',                       # ONLY FOR MODEL: The django content type of the model
             'can_allow_create': True,                                # ONLY FOR MODEL: If a link to create an instance via django admin should be inserted
+            'filter_fields': {'owner__isnull': True},                # ONLY FOR MODEL: Optional, allow custom filers to be applied to all searches for this chooser
             'fields_to_save': ['id'] + RATE_CHOOSER_DISPLAY_FIELDS,  # ONLY FOR REMOTE: The remote objects fields to save to the DB. Leave empty to save the whole object.
             'remote_endpoint': 'http://...'                          # ONLY FOR REMOTE: The remote API endpoint.
             'pk_name': 'uuid',                                       # The primary key name of the model

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -27,32 +27,34 @@ class TestModelChooserWidget(TestCase):
             'pk_name': 'id',
         }
 
+    CHOOSER_NAME = 'test_chooser'
+
     def test_get_target_model_string(self):
-        widget = widgets.ModelChooserWidget('wagtailcore.Page', **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, 'wagtailcore.Page', **self.get_widget_options())
         model = widget.target_model()
         self.assertEqual(model.__class__, Page)
 
     def test_get_target_model_class(self):
-        widget = widgets.ModelChooserWidget(Page, **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, Page, **self.get_widget_options())
         model = widget.target_model()
         self.assertEqual(model.__class__, Page)
 
     def test_get_instance_none_value(self):
-        widget = widgets.ModelChooserWidget(Page, **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, Page, **self.get_widget_options())
         self.assertFalse(widget.get_instance(''))
 
     def test_get_instance_page_value(self):
-        widget = widgets.ModelChooserWidget(Page, **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, Page, **self.get_widget_options())
         self.assertEqual(widget.get_instance(2), self.root_page)
 
     def test_get_instance_no_page_value_is_none(self):
-        widget = widgets.ModelChooserWidget(Page, **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, Page, **self.get_widget_options())
         self.assertEqual(widget.get_instance(999), None)
 
     def test_url_builder(self):
-        widget = widgets.ModelChooserWidget(Page, **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, Page, **self.get_widget_options())
         url = widget.get_endpoint()
-        self.assertEqual(url, '/admin/modelchoosers/api/v1/model/wagtailcore.Page')
+        self.assertEqual(url, '/admin/modelchoosers/api/v1/model/%s' % self.CHOOSER_NAME)
 
     def test_get_internal_value(self):
         id_ = uuid.uuid4()
@@ -62,27 +64,29 @@ class TestModelChooserWidget(TestCase):
 
         stub = Stub()
         stub.pk = id_
-        widget = widgets.ModelChooserWidget(Page, **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, Page, **self.get_widget_options())
         value = widget.get_internal_value(stub)
         self.assertEqual(value, str(id_))
 
     def test_get_js_init_data(self):
-        widget = widgets.ModelChooserWidget(Page, **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, Page, **self.get_widget_options())
         data = widget.get_js_init_data('field-1', None, self.root_page)
+        self.maxDiff = None
         expected_data = {
             'label': 'Page',
             'required': True,
             'initial_display_value': 'Welcome to your new Wagtail site!',
             'display': 'title',
             'list_display': [{'name': 'title', 'label': 'Title'}],
-            'endpoint': '/admin/modelchoosers/api/v1/model/wagtailcore.Page',
+            'endpoint': '/admin/modelchoosers/api/v1/model/%s' % self.CHOOSER_NAME,
+            'createEndpoint': None,
             'pk_name': 'id',
         }
 
         self.assertEqual(data, expected_data)
 
     def test_render_js_init(self):
-        widget = widgets.ModelChooserWidget(Page, **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, Page, **self.get_widget_options())
         js_init = widget.render_js_init('field-1', None, self.root_page)
 
         expected_pattern = (
@@ -98,11 +102,11 @@ class TestModelChooserWidget(TestCase):
         self.assertRegex(js_init, expected_pattern)
 
     def test_render_html(self):
-        widget = widgets.ModelChooserWidget(Page, **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, Page, **self.get_widget_options())
         html = widget.render_html('test', None, {})
         self.assertIn('<input type="hidden" value="" name="test" >', html)
 
     def test_render_html_with_value(self):
-        widget = widgets.ModelChooserWidget(Page, **self.get_widget_options())
+        widget = widgets.ModelChooserWidget(self.CHOOSER_NAME, Page, **self.get_widget_options())
         html = widget.render_html('test', self.root_page, {})
         self.assertIn('<input type="hidden" value="2" name="test" >', html)

--- a/wagtailmodelchoosers/blocks.py
+++ b/wagtailmodelchoosers/blocks.py
@@ -17,7 +17,7 @@ class ModelChooserBlock(ChooserBlock):
 
         self.chooser = chooser
         self.content_type = options.pop('content_type')
-        self.can_allow_create = options.pop('can_allow_create')
+        self.can_allow_create = options.pop('can_allow_create', False)
         self.label = options.pop('label', chooser)
         self.display = options.pop('display', 'title')
         self.list_display = options.pop('list_display', list(flatten([self.display])))

--- a/wagtailmodelchoosers/blocks.py
+++ b/wagtailmodelchoosers/blocks.py
@@ -36,6 +36,7 @@ class ModelChooserBlock(ChooserBlock):
     @cached_property
     def widget(self):
         return ModelChooserWidget(
+            self.chooser,
             self.target_model,
             required=self._required,
             label=self.label,

--- a/wagtailmodelchoosers/edit_handlers.py
+++ b/wagtailmodelchoosers/edit_handlers.py
@@ -21,6 +21,7 @@ class BaseModelChooserPanel(BaseChooserPanel):
     def widget_overrides(cls):
         return {
             cls.field_name: ModelChooserWidget(
+                cls.chooser,
                 cls.target_model(),
                 required=cls.get_required(),
                 label=cls.label,
@@ -57,6 +58,7 @@ class ModelChooserPanel(object):
         return type(str('_ModelChooserPanel'), (BaseModelChooserPanel,), {
             'model': model,
             'field_name': self.field_name,
+            'chooser': self.chooser,
             'label': self.label,
             'display': self.display,
             'list_display': self.list_display,

--- a/wagtailmodelchoosers/permissions.py
+++ b/wagtailmodelchoosers/permissions.py
@@ -18,11 +18,5 @@ class IsRegisteredModelChooserModel(BasePermission):
 
     def has_permission(self, request, view):
         params = request.parser_context.get('kwargs')
-        app_name = params.get('app_name')
-        model_name = params.get('model_name')
-
-        model_path = u'{}.{}'.format(app_name, model_name)
-        return model_path in self.configured_model_chooser_models()
-
-    def configured_model_chooser_models(self):
-        return [chooser['content_type'] for chooser in settings.MODEL_CHOOSERS_OPTIONS.values()]
+        chooser_name = params.get('chooser')
+        return chooser_name in settings.MODEL_CHOOSERS_OPTIONS

--- a/wagtailmodelchoosers/utils.py
+++ b/wagtailmodelchoosers/utils.py
@@ -92,7 +92,7 @@ def first_non_empty(data_or_instance, field_or_fields, default=None):
         obj = data_or_instance
 
     # Find the first non-empty.
-    if isinstance(field_or_fields, str):
+    if isinstance(field_or_fields, basestring):
         return getattr(obj, field_or_fields, default)
 
     elif isinstance(field_or_fields, (tuple, list)):

--- a/wagtailmodelchoosers/views.py
+++ b/wagtailmodelchoosers/views.py
@@ -34,8 +34,10 @@ class ModelView(ListModelMixin, GenericViewSet):
         if hasattr(cls, 'SEARCH_FIELDS'):
             queries = [Q(**{search_field: search}) for search_field in cls.SEARCH_FIELDS]
         else:
-            search_fields = [field.name for field in cls._meta.get_fields() if isinstance(field, CharField)]
-            for field in cls._meta.get_fields():
+            search_fields = [
+                field.name for field in cls._meta.get_fields()
+                if isinstance(field, CharField)]
+            for field in search_fields:
                 if isinstance(field, CharField):
                     kwargs = {}
                     param_name = '%s__icontains' % field.name

--- a/wagtailmodelchoosers/wagtail_hooks.py
+++ b/wagtailmodelchoosers/wagtail_hooks.py
@@ -27,7 +27,7 @@ def wagtailmodelchoosers_admin_js():
 def wagtailmodelchoosers_admin_urls():
     return [
         url(
-            r'^modelchoosers/api/v1/model/(?P<app_name>[\w-]+).(?P<model_name>\w+)',
+            r'^modelchoosers/api/v1/model/(?P<chooser>[\w-]+)',
             ModelView.as_view({'get': 'list'}),
             name='wagtailmodelchoosers_api_model'
         ),

--- a/wagtailmodelchoosers/widgets.py
+++ b/wagtailmodelchoosers/widgets.py
@@ -33,9 +33,9 @@ class ModelChooserWidget(WidgetWithScript, widgets.Input):
 
         super(ModelChooserWidget, self).__init__(**kwargs)
 
-    @cached_property
+    @property
     def target_model(self):
-        if isinstance(self._target_model, str):
+        if isinstance(self._target_model, basestring):
             return apps.get_model(self._target_model)
 
         else:

--- a/wagtailmodelchoosers/widgets.py
+++ b/wagtailmodelchoosers/widgets.py
@@ -17,7 +17,8 @@ class ModelChooserWidget(WidgetWithScript, widgets.Input):
     is_hidden = True
     template_name = 'wagtailmodelchoosers/widgets/model_chooser.html'
 
-    def __init__(self, target_model, display, list_display, required=True, **kwargs):
+    def __init__(self, chooser, target_model, display, list_display, required=True, **kwargs):
+        self.chooser = chooser
         self.required = required
         self._target_model = target_model
         self.label = kwargs.pop('label', self.get_class_name()[1])
@@ -78,10 +79,8 @@ class ModelChooserWidget(WidgetWithScript, widgets.Input):
                 return result
 
     def get_endpoint(self):
-        app, class_name = self.get_class_name()
-
         from django.core.urlresolvers import reverse
-        return reverse('wagtailmodelchoosers_api_model', args=[app, class_name])
+        return reverse('wagtailmodelchoosers_api_model', args=[self.chooser])
 
     def get_create_endpoint(self):
         if self.can_allow_create is not True:


### PR DESCRIPTION
# Why?
We need the ability to add filters that apply to all searches of a model chooser, but we do not want to globally define these filters on the model

# What changed?
Previously, the API endpoint was unaware of the chooser being used for the request, so it was unable to pull chooser-specific options. It only knew about the model, and had to rely on that for customization. Replace the url params for the model chooser to pass the chooser name instead of the model so that the view can read extra custom options. The model is still accessible from the chooser options.

Tests have also been updated to resolve previously failing tests as well as the new changes.

## New config:
`filter_fields` applies filter queries to all searches for a chooser.

